### PR TITLE
Updated installation instructions to Pakagecloud.io

### DIFF
--- a/source/content/examples/snippet5_install_varnish
+++ b/source/content/examples/snippet5_install_varnish
@@ -1,6 +1,9 @@
-apt-get install apt-transport-https
-curl https://repo.varnish-cache.org/GPG-key.txt | apt-key add -
-echo "deb https://repo.varnish-cache.org/ubuntu/ trusty varnish-4.1" \
-     >> /etc/apt/sources.list.d/varnish-cache.list
+curl -L https://packagecloud.io/varnishcache/varnish41/gpgkey | sudo apt-key add -
+
+sudo nano /etc/apt/sources.list.d/varnishcache_varnish41.list
+
+deb https://packagecloud.io/varnishcache/varnish41/ubuntu/ trusty main
+deb-src https://packagecloud.io/varnishcache/varnish41/ubuntu/ trusty main
+
 apt-get update
 apt-get install varnish

--- a/source/content/examples/update_install_varnish
+++ b/source/content/examples/update_install_varnish
@@ -1,2 +1,2 @@
-sudo apt~get update
-sudo apt~get install varnish
+sudo apt-get update
+sudo apt-get install varnish

--- a/source/content/examples/varnish_install_repo
+++ b/source/content/examples/varnish_install_repo
@@ -1,7 +1,6 @@
-sudo curl http://repo.varnish~cache.org/debian/GPG~key.txt | sudo apt~key add ~
+curl -L https://packagecloud.io/varnishcache/varnish41/gpgkey | sudo apt-key add -
 
-sudo nano /etc/apt/sources.list
+sudo nano /etc/apt/sources.list.d/varnishcache_varnish41.list	
 
-deb http://repo.varnish~cache.org/ubuntu/ trusty varnish~4.1
-
-
+deb https://packagecloud.io/varnishcache/varnish41/ubuntu/ trusty main
+deb-src https://packagecloud.io/varnishcache/varnish41/ubuntu/ trusty main

--- a/source/content/tutorials/varnish/index.rst
+++ b/source/content/tutorials/varnish/index.rst
@@ -17,8 +17,8 @@ Use Varnish on your Website
   vcl
   vcl_examples
 
-Varnish can cache any web based content, meaning any CMS, intranet, ReST/Web API, 
-or Streaming media content can literally gain performance increases in the range 
+Varnish can cache any web based content, meaning any CMS, intranet, ReST/Web API,
+or Streaming media content can literally gain performance increases in the range
 of 300-1000x times compared to what standard web servers can provide.
 
 But, before you get to Varnish, You want to **get Varnish**. You have two choices:
@@ -65,7 +65,7 @@ From source:
 Red Hat / CentOS
 ................
 
-The latest version is available as prebuilt RPMs (el5 and el6) on `repo.varnish-cache.org`_ .
+The latest version is available as prebuilt RPMs (el5 and el6) on `https://packagecloud.io/varnishcache/`_ .
 
 See the online Red Hat installation instructions for more information.
 
@@ -90,13 +90,20 @@ Please note that this might not be the latest version of Varnish.
 If you need a newer version of Varnish for the OS version you are using,
 please follow the instructions in the Varnish Book or as shown below.
 
-.. code-block:: bash
+- Start by grabbing the repository
 
-  $ curl https://repo.varnish-cache.org/ubuntu/GPG-key.txt | apt-key add -
-  $ echo "deb https://repo.varnish-cache.org/ubuntu/ trusty varnish-4.0" >> \
-  /etc/apt/sources.list.d/varnish-cache.list
+- Add the repository to the source list and save
 
-If you are installing Varnish Cache 4.1, replace varnish-4.0 for varnish-4.1 in
+.. literalinclude:: /content/examples/varnish_install_repo
+	:language: bash
+
+- Run update and install
+
+.. literalinclude:: /content/examples/update_install_varnish
+	:language: bash
+For more information visit the `packagecloud`_ page.
+
+If you are installing Varnish Cache 4.0, replace varnish41 for varnish40 in
 the command above. Instructions for Debian and Ubuntu are the same.
 
 
@@ -232,5 +239,5 @@ And finally, the true test of a **brave heart!**
 Using source: https://www.varnish-cache.org/docs/trunk/installation/install.html#compiling-varnish-from-source
 
 .. _`products at our website`: https://www.varnish-software.com/products/varnish-plus
-.. _`repo.varnish-cache.org`: https://repo.varnish-cache.org
-.. _`repository source`: http://repo.varnish-cache.org/source/
+.. _`repository source`: https://varnish-cache.org/releases/
+.. _`packagecloud`: https://packagecloud.io/varnishcache

--- a/source/content/tutorials/varnish/varnish_ubuntu.rst
+++ b/source/content/tutorials/varnish/varnish_ubuntu.rst
@@ -30,6 +30,9 @@ It is recommended that you install the Varnish package from its repository.
 
 .. literalinclude:: /content/examples/update_install_varnish
 	:language: bash
+For more information visit the `packagecloud`_ page.
+
+.. _`packagecloud`: https://packagecloud.io/varnishcache/varnish41
 
 Step 2: Configure Varnish
 --------------------------


### PR DESCRIPTION
Since Varnish Cache switched to packagecloud for package hosting, the installation from this Wiki was not working anymore.

Allso, it never worked because of ~ in apt~get, I also fixed this.