### PR TITLE
Fix curley bracket in 'Enabling cache for static files' -example

### DIFF
--- a/source/content/tutorials/varnish/sample_vclTemplate.rst
+++ b/source/content/tutorials/varnish/sample_vclTemplate.rst
@@ -208,7 +208,7 @@ Enabling cache for static files
 ...............................
 
 .. literalinclude:: /content/templates/vcl_defaultSample_mattias.vcl
-  :lines: 298,310-312,349,348-349
+  :lines: 298,310-312,348-349
 
 Streaming
 .........


### PR DESCRIPTION
Patch changes from : 

```
  sub vcl_backend_response {
    if (bereq.url ~ "^[^?]*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|otf|ogg|ogm|opus|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)(\?.*)?$") {
      unset beresp.http.set-cookie;
    }
  }
    return (deliver);
  }
```

to
```
  sub vcl_backend_response {
    if (bereq.url ~ "^[^?]*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|otf|ogg|ogm|opus|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)(\?.*)?$") {
      unset beresp.http.set-cookie;
    }
    return (deliver);
  }
```